### PR TITLE
Add python3-pip dependency in attempt to fix build

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -7,9 +7,7 @@ Type=oneshot
 User=__APP__
 Group=__APP__
 WorkingDirectory=__FINALPATH__
-ExecStart=__FINALPATH__/yunomonitor.py -c __FINALPATH__/conf/__APP__.yml 
-User=root
-Group=root
+ExecStart=__FINALPATH__/venv/bin/python -- yunomonitor.py -c __FINALPATH__/conf/__APP__.yml 
 
 [Install]
 WantedBy=multi-user.target

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -7,6 +7,7 @@ Type=oneshot
 User=__APP__
 Group=__APP__
 WorkingDirectory=__FINALPATH__
+EnvironmentFile=__FINALPATH__/venv/bin/activate
 ExecStart=__FINALPATH__/yunomonitor.py -c __FINALPATH__/conf/__APP__.yml 
 User=root
 Group=root

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -7,7 +7,6 @@ Type=oneshot
 User=__APP__
 Group=__APP__
 WorkingDirectory=__FINALPATH__
-EnvironmentFile=__FINALPATH__/venv/bin/activate
 ExecStart=__FINALPATH__/yunomonitor.py -c __FINALPATH__/conf/__APP__.yml 
 User=root
 Group=root

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,9 +5,9 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="whois smartmontools python3-pip python3-venv python3-dev"
+pkg_dependencies="whois smartmontools python3-pip python3-venv python3-dev libdbus-1-dev pkd-config"
 
-python_packages="cryptography paramiko yaml dnspython requests-toolbel spf dbus"
+python_packages="cryptography paramiko pyyaml dnspython requests-toolbelt pyspf dbus-python"
 
 #=================================================
 # PERSONAL HELPERS

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="whois smartmontools python3-pip python3-venv python3-dev libdbus-1-dev pkg-config"
+pkg_dependencies="whois smartmontools python3-pip python3-venv python3-dev libdbus-1-dev pkg-config dbus"
 
 python_packages="cryptography paramiko pyyaml dnspython requests-toolbelt pyspf dbus-python"
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="whois smartmontools python3-pip python3-venv python3-dev libdbus-1-dev pkg-config dbus"
+pkg_dependencies="whois smartmontools python3-pip python3-venv python3-dev libdbus-1-dev pkg-config libglib2.0-dev"
 
 python_packages="cryptography paramiko pyyaml dnspython requests-toolbelt pyspf dbus-python"
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="whois smartmontools python3-pip python3-venv python3-dev libdbus-1-dev pkd-config"
+pkg_dependencies="whois smartmontools python3-pip python3-venv python3-dev libdbus-1-dev pkg-config"
 
 python_packages="cryptography paramiko pyyaml dnspython requests-toolbelt pyspf dbus-python"
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="python3-dbus python3-cryptography python3-paramiko python3-yaml python3-dnspython python3-requests-toolbelt python3-spf whois smartmontools python3-pip"
+pkg_dependencies="python3-dbus python3-cryptography python3-paramiko python3-yaml python3-dnspython python3-requests-toolbelt python3-spf whois smartmontools python3-pip python3-venv"
 
 #=================================================
 # PERSONAL HELPERS

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="python3-dbus python3-cryptography python3-paramiko python3-yaml python3-dnspython python3-requests-toolbelt python3-spf whois smartmontools"
+pkg_dependencies="python3-dbus python3-cryptography python3-paramiko python3-yaml python3-dnspython python3-requests-toolbelt python3-spf whois smartmontools python3-dev"
 
 #=================================================
 # PERSONAL HELPERS

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="python3-dbus python3-cryptography python3-paramiko python3-yaml python3-dnspython python3-requests-toolbelt python3-spf whois smartmontools python3-dev"
+pkg_dependencies="python3-dbus python3-cryptography python3-paramiko python3-yaml python3-dnspython python3-requests-toolbelt python3-spf whois smartmontools python3-pip"
 
 #=================================================
 # PERSONAL HELPERS

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="whois smartmontools python3-pip python3-venv python3-dev libdbus-1-dev pkg-config libglib2.0-dev"
+pkg_dependencies="whois smartmontools python3-pip python3-venv python3-dev libdbus-1-dev pkg-config libglib2.0-dev libyaml-dev"
 
 python_packages="cryptography paramiko pyyaml dnspython requests-toolbelt pyspf dbus-python"
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -7,7 +7,7 @@
 # dependencies used by the app
 pkg_dependencies="whois smartmontools python3-pip python3-venv python3-dev"
 
-python_packages="cryptgraphy paramiko yaml dnspython requests-toolbel spf dbus"
+python_packages="cryptography paramiko yaml dnspython requests-toolbel spf dbus"
 
 #=================================================
 # PERSONAL HELPERS

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,9 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="python3-dbus python3-cryptography python3-paramiko python3-yaml python3-dnspython python3-requests-toolbelt python3-spf whois smartmontools python3-pip python3-venv"
+pkg_dependencies="whois smartmontools python3-pip python3-venv python3-dev"
+
+python_packages="cryptgraphy paramiko yaml dnspython requests-toolbel spf dbus"
 
 #=================================================
 # PERSONAL HELPERS

--- a/scripts/install
+++ b/scripts/install
@@ -96,8 +96,7 @@ ynh_systemd_action --service_name=nginx --action=reload
 ynh_script_progression --message="Building Yunomonitor..."
 
 pushd "$final_path"
-	python3 -m venv venv
-	venv/bin/pip install --upgrade pip
+	python3 -m venv -- venv --system-site-packages --upgrade-deps
 	venv/bin/pip install pycryptodome
 popd
 

--- a/scripts/install
+++ b/scripts/install
@@ -96,7 +96,8 @@ ynh_systemd_action --service_name=nginx --action=reload
 ynh_script_progression --message="Building Yunomonitor..."
 
 pushd "$final_path"
-	python3 -m venv -- venv --system-site-packages --upgrade-deps
+	python3 -m venv -- venv --upgrade-deps
+	venv/bin/pip install $python_packages
 	venv/bin/pip install pycryptodome
 popd
 

--- a/scripts/install
+++ b/scripts/install
@@ -96,7 +96,9 @@ ynh_systemd_action --service_name=nginx --action=reload
 ynh_script_progression --message="Building Yunomonitor..."
 
 pushd "$final_path"
-	pip3 install pycryptodome
+	python3 -m venv venv
+	venv/bin/pip install --upgrade pip
+	venv/bin/pip install pycryptodome
 popd
 
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -45,7 +45,8 @@ ynh_secure_remove --file="$final_path"
 ynh_script_progression --message="Removing NGINX web server configuration..." --weight=1
 
 # Remove the dedicated NGINX config
-ynh_remove_nginx_config
+ynh_secure_remove --file="/etc/nginx/conf.d/$domain.d/000-$app.conf"
+ynh_systemd_action --service_name=nginx --action=reload
 
 #=================================================
 # REMOVE DEPENDENCIES

--- a/scripts/restore
+++ b/scripts/restore
@@ -80,7 +80,9 @@ ynh_install_app_dependencies $pkg_dependencies
 ynh_script_progression --message="Building Yunomonitor..."
 
 pushd "$final_path"
-	pip3 install pycryptodome
+	python3 -m venv venv
+	venv/bin/pip install --upgrade pip
+	venv/bin/pip install pycryptodome
 popd
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -106,9 +106,10 @@ ynh_install_app_dependencies $pkg_dependencies
 #=================================================
 ynh_script_progression --message="Building Yunomonitor..."
 
+ynh_secure_remove "$final_path/venv"
+
 pushd "$final_path"
-	python3 -m venv venv
-	venv/bin/pip install --upgrade pip
+	python3 -m venv -- venv --system-site-packages --upgrade-deps
 	venv/bin/pip install pycryptodome
 popd
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -109,7 +109,8 @@ ynh_script_progression --message="Building Yunomonitor..."
 ynh_secure_remove "$final_path/venv"
 
 pushd "$final_path"
-	python3 -m venv -- venv --system-site-packages --upgrade-deps
+	python3 -m venv -- venv --upgrade-deps
+	venv/bin/pip install $python_packages
 	venv/bin/pip install pycryptodome
 popd
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -107,7 +107,9 @@ ynh_install_app_dependencies $pkg_dependencies
 ynh_script_progression --message="Building Yunomonitor..."
 
 pushd "$final_path"
-	pip3 install pycryptodome
+	python3 -m venv venv
+	venv/bin/pip install --upgrade pip
+	venv/bin/pip install pycryptodome
 popd
 
 #=================================================


### PR DESCRIPTION
## Problem

- `bookworm` install fails https://ci-apps-bookworm.yunohost.org/ci/apps/yunomonitor/

## Solution

- Speculatively add `python3-pip` dependency.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
